### PR TITLE
Fix word-break in source links

### DIFF
--- a/klimaat_helpdesk/static/components/blocks/_disclosure.scss
+++ b/klimaat_helpdesk/static/components/blocks/_disclosure.scss
@@ -34,6 +34,9 @@
     @include grid-container;
     margin-bottom: 80px;
     padding-bottom: 80px;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;
   }
 
   .disclosure__disclosure-title {


### PR DESCRIPTION
This PR fixes #89.

The solution comes from [CSS Tricks](https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/).